### PR TITLE
Optimize load_py for memory and speed

### DIFF
--- a/TorchSharp.PyBridge/PyBridgeModuleExtensions.cs
+++ b/TorchSharp.PyBridge/PyBridgeModuleExtensions.cs
@@ -134,8 +134,10 @@ namespace TorchSharp.PyBridge {
 
             var (_, unexpectedKeys) = load_state_dict(module, unpickledConstructors, strict, skip);
 
-            // Close stream now that tensor streams have been read.
-            stream.Close ();
+            if (!leaveOpen) {
+                // Close stream now that tensor streams have been read.
+                stream.Close ();
+            }
 
             if (loadedParameters is null) {
                 return module;

--- a/TorchSharp.PyBridge/PyBridgeModuleExtensions.cs
+++ b/TorchSharp.PyBridge/PyBridgeModuleExtensions.cs
@@ -123,7 +123,7 @@ namespace TorchSharp.PyBridge {
 
             // Unpickle the state dictionary into memory.
             // Keep stream open because tensors will not get deserialized yet.
-            var unpickled = PyTorchUnpickler.UnpickleStateDict(stream, leaveOpen: true);
+            var unpickled = PyTorchUnpickler.UnpickleStateDict(stream, leaveOpen: true, skipTensorRead: true);
 
             // Convert the hashtable to a dictionary of string->tensor
             Dictionary<string, PyTorchUnpickler.TensorConstructorArgs> unpickledConstructorArgs = new();
@@ -208,7 +208,7 @@ namespace TorchSharp.PyBridge {
                 else {
                     // Type conversion with intermediate tensor required.
                     // This will load onto cpu first before copying to target.
-                    using torch.Tensor temp = _source.read();
+                    using torch.Tensor temp = _source.readTensorFromStream();
                     state_dict[key].copy_(temp);
                 }
             }

--- a/TorchSharp.PyBridge/PyTorchUnpickler.cs
+++ b/TorchSharp.PyBridge/PyTorchUnpickler.cs
@@ -26,8 +26,12 @@ namespace TorchSharp.PyBridge {
         /// </summary>
         /// <param name="stream">Stream of the file to load</param>
         /// <param name="leaveOpen">true to leave the stream open after saving the file</param>
+        /// <param name="skipTensorRead">true to return descriptor objects and streams instead of tensors so that they can be loaded later</param>
         /// <returns>The loaded state_dict</returns>
         public static Hashtable UnpickleStateDict(Stream stream, bool leaveOpen = false, bool skipTensorRead = false) {
+            if (skipTensorRead && !leaveOpen)
+                throw new ArgumentException("leaveOpen must be true when skipTensorRead is true");
+
             // Make sure it's a zip file
             // If it's not, then it was saved using legacy torch save and we don't support it (yet, at least)
             // Check the local file signature


### PR DESCRIPTION
This PR implements several strategies to improve the memory footprint and speed performance of `load_py` while maintaining backwards compatibility:

- The Zip archive streams are not opened and read until the moment they are needed.
- The Zip archive streams are read in the order that they are stored in the file to reduce random file seeks.
- Avoid holding intermediate tensors in memory before they are copied to the target module.
- Avoid intermediate copies of tensors during read, if possible.
- Any intermediate tensors or streams are allocated and disposed of as soon as possible.

## Test

These tests load the llama-2-7B-chat pickled model on a MacBook Air, M2 processor, with 24GB of memory and SSD.

### CPU Model

#### Baseline - 41 secs

<img width="202" alt="cpu-baseline-41-secs" src="https://github.com/user-attachments/assets/c62590ed-9afb-4ea3-aeff-13f816c3bfef">

#### With Optimizations - 9.6 secs

<img width="206" alt="cpu-optimized-9 6-secs" src="https://github.com/user-attachments/assets/b6959f01-846b-4ceb-8e40-05a0474cf018">

### MPS Model

#### Before - 41 secs

<img width="207" alt="mps-baseline-41-secs" src="https://github.com/user-attachments/assets/f84ebb5f-eea5-434a-a360-704fe3dc13b4">

#### After - 30 secs

<img width="204" alt="mps-optimized-30secs" src="https://github.com/user-attachments/assets/4d90ec84-4d46-4b4a-b2ea-c3d05460c254">
